### PR TITLE
Upgrade to python:3.10.10 container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.9-slim-bullseye
+FROM python:3.10.10-slim-bullseye
 WORKDIR /app
 COPY . .
 RUN pip install --no-cache-dir --upgrade pip


### PR DESCRIPTION
### Summary

This latest version fixes recent CVEs in OpenSSL in the underlying Debian container.

### To test

Build container and confirm website is still visible.